### PR TITLE
Switch to use stdlib for simple computation

### DIFF
--- a/3scaleAdapter/Gopkg.lock
+++ b/3scaleAdapter/Gopkg.lock
@@ -825,7 +825,6 @@
     "pkg/util/intstr",
     "pkg/util/json",
     "pkg/util/net",
-    "pkg/util/rand",
     "pkg/util/runtime",
     "pkg/util/sets",
     "pkg/util/validation",
@@ -931,7 +930,6 @@
     "istio.io/istio/mixer/template/authorization",
     "istio.io/istio/mixer/template/logentry",
     "istio.io/istio/pkg/log",
-    "k8s.io/apimachinery/pkg/util/rand",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/3scaleAdapter/pkg/threescale/metrics/prometheus_test.go
+++ b/3scaleAdapter/pkg/threescale/metrics/prometheus_test.go
@@ -1,10 +1,9 @@
 package metrics
 
 import (
+	"math/rand"
 	"testing"
 	"time"
-
-	"k8s.io/apimachinery/pkg/util/rand"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 )
@@ -102,7 +101,7 @@ func TestServe(t *testing.T) {
 
 func randCounterInc(t *testing.T, inc func()) int {
 	t.Helper()
-	incrementBy := rand.IntnRange(1, 10)
+	incrementBy := int(rand.Int31n(9) + 1)
 	for i := 1; i <= incrementBy; i++ {
 		inc()
 	}


### PR DESCRIPTION
When writing the metrics test, the wrong package was imported. Use `rand` package from standard library for simple match computation.