### PR TITLE
System status code metrics

### DIFF
--- a/3scaleAdapter/pkg/threescale/metrics/prometheus.go
+++ b/3scaleAdapter/pkg/threescale/metrics/prometheus.go
@@ -124,7 +124,18 @@ func NewStatusReport(endpoint string, code int, url string, target Target) Statu
 	}
 }
 
-// ObserveLatency reports a metric to a latency histogram
+// ReportMetrics reports a LatencyReport and StatusReport to Prometheus.
+// It ignores errors from creating metrics so if the error needs to be handled outside
+// of being logged, the metrics should be reported directly.
+func (r *Reporter) ReportMetrics(serviceID string, l LatencyReport, s StatusReport) {
+	if r != nil && r.shouldReport {
+		r.ObserveLatency(serviceID, l)
+		r.ReportStatus(serviceID, s)
+	}
+}
+
+// ObserveLatency reports a metric to a latency histogram.
+// Logs and returns an error in cases where the metric has not been reported.
 func (r *Reporter) ObserveLatency(serviceID string, l LatencyReport) error {
 	if r != nil && r.shouldReport {
 		o, err := l.getObserver(serviceID)
@@ -139,6 +150,7 @@ func (r *Reporter) ObserveLatency(serviceID string, l LatencyReport) error {
 }
 
 // ReportStatus reports a hit to 3scale backend and reports status code of the result
+// Logs and returns an error in cases where the metric has not been reported.
 func (r *Reporter) ReportStatus(serviceID string, s StatusReport) error {
 	if r != nil && r.shouldReport {
 		codeStr := strconv.Itoa(s.Code)

--- a/3scaleAdapter/pkg/threescale/threescale.go
+++ b/3scaleAdapter/pkg/threescale/threescale.go
@@ -53,7 +53,7 @@ type (
 		metricsReporter *prometheus.Reporter
 	}
 
-	reportLatency func(serviceID string, l prometheus.LatencyReport) error
+	reportMetrics func(serviceID string, l prometheus.LatencyReport, s prometheus.StatusReport)
 )
 
 // For this PoC I'm using the authorize template, but we should check if the quota template
@@ -114,7 +114,7 @@ func (s *Threescale) reportUsage(cfg *config.Params, instances []*logentry.Insta
 		if s.conf.systemCache != nil {
 			pce, proxyConfErr = s.conf.systemCache.get(cfg, c)
 		} else {
-			pce, proxyConfErr = getFromRemote(cfg, c, s.conf.metricsReporter.ObserveLatency)
+			pce, proxyConfErr = getFromRemote(cfg, c, s.reportMetrics)
 		}
 
 		if proxyConfErr != nil {
@@ -248,7 +248,7 @@ func (s *Threescale) isAuthorized(cfg *config.Params, request authorization.Inst
 	if s.conf.systemCache != nil {
 		pce, proxyConfErr = s.conf.systemCache.get(cfg, c)
 	} else {
-		pce, proxyConfErr = getFromRemote(cfg, c, s.conf.metricsReporter.ObserveLatency)
+		pce, proxyConfErr = getFromRemote(cfg, c, s.reportMetrics)
 	}
 
 	if proxyConfErr != nil {
@@ -312,8 +312,7 @@ func (s *Threescale) doAuth(svcID string, userKey string, request authorization.
 // a reporter has not been configured
 func (s *Threescale) reportMetrics(svcID string, l prometheus.LatencyReport, sr prometheus.StatusReport) {
 	if s.conf != nil {
-		s.conf.metricsReporter.ObserveLatency(svcID, l)
-		s.conf.metricsReporter.ReportStatus(svcID, sr)
+		s.conf.metricsReporter.ReportMetrics(svcID, l, sr)
 	}
 }
 


### PR DESCRIPTION
This change pulls in the latest 3scale system client dependency and leverages it to gather status codes and reports to Prometheus