### PR TITLE
Cache refresh

### DIFF
--- a/3scaleAdapter/cmd/main.go
+++ b/3scaleAdapter/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -56,7 +57,7 @@ func stringToLogLevel(loglevel string) (log.Level, error) {
 		"none":  log.NoneLevel,
 	}
 
-	if val, ok := stringToLevel[loglevel]; ok {
+	if val, ok := stringToLevel[strings.ToLower(loglevel)]; ok {
 		return val, nil
 	}
 

--- a/3scaleAdapter/pkg/threescale/proxy_conf.go
+++ b/3scaleAdapter/pkg/threescale/proxy_conf.go
@@ -19,7 +19,7 @@ const (
 	DefaultCacheTTL = time.Duration(time.Minute * 5)
 
 	// DefaultCacheRefreshBuffer - Default time difference to refresh the cache element before expiry time
-	DefaultCacheRefreshBuffer = time.Duration(time.Minute * 1)
+	DefaultCacheRefreshBuffer = time.Duration(time.Minute * 3)
 
 	// DefaultCacheLimit - Default max number of items that can be stored in the cache at any time
 	DefaultCacheLimit = 1000

--- a/3scaleAdapter/pkg/threescale/proxy_conf.go
+++ b/3scaleAdapter/pkg/threescale/proxy_conf.go
@@ -217,7 +217,7 @@ func (pc *ProxyConfigCache) refreshCache(exitC chan bool) {
 			}
 		default:
 			pc.RefreshCache()
-			<-time.After(pc.ttl)
+			<-time.After(pc.refreshBuffer)
 		}
 	}
 }


### PR DESCRIPTION
This change fixes a bug in the cache refresh goroutine where the wrong injected value was being used. Increases the timeout to two minutes which was discussed as a reasonable value for requests to 3scale system.

Adds some changes to allow an operator to adjust the behaviour of the cache via configuration. This along with other config needs documentation.